### PR TITLE
decreased minSdkVersion in app/build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "ch.swissonid.design_samples"
-        minSdkVersion 19
+        minSdkVersion 9
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This project works with minSdkVersion starting from 9, so I suggest decrease it from 19 to 9, especially since it demonstrates usage of support lib, which targets level 7 (however some dependencies in this project require min level 9).
